### PR TITLE
Fix for disappearing Web menu in Qgis on Ubuntu

### DIFF
--- a/quick_osm.py
+++ b/quick_osm.py
@@ -117,6 +117,7 @@ class QuickOSM:
             self.iface.mainWindow())
         # noinspection PyUnresolvedReferences
         self.osmFileAction.triggered.connect(self.openOsmFileDockWidget)
+        self.iface.addPluginToWebMenu(u"&Quick OSM",self.osmFileAction)
         self.osmFileDockWidget = OsmFileDockWidget()
         self.iface.addDockWidget(
             Qt.RightDockWidgetArea, self.osmFileDockWidget)
@@ -130,6 +131,7 @@ class QuickOSM:
             self.iface.mainWindow())
         # noinspection PyUnresolvedReferences
         self.myQueriesAction.triggered.connect(self.openMyQueriesDockWidget)
+        self.iface.addPluginToWebMenu(u"&Quick OSM",self.myQueriesAction)
         self.myQueriesDockWidget = MyQueriesDockWidget()
         self.iface.addDockWidget(
             Qt.RightDockWidgetArea, self.myQueriesDockWidget)
@@ -143,6 +145,7 @@ class QuickOSM:
             self.iface.mainWindow())
         # noinspection PyUnresolvedReferences
         self.queryAction.triggered.connect(self.openQueryDockWidget)
+        self.iface.addPluginToWebMenu(u"&Quick OSM",self.queryAction)
         self.queryDockWidget = QueryDockWidget()
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.queryDockWidget)
         self.queryDockWidget.hide()
@@ -155,6 +158,7 @@ class QuickOSM:
             self.iface.mainWindow())
         # noinspection PyUnresolvedReferences
         self.quickQueryAction.triggered.connect(self.openQuickQueryDockWidget)
+        self.iface.addPluginToWebMenu(u"&Quick OSM",self.quickQueryAction)
         self.quickQueryDockWidget = QuickQueryDockWidget()
         self.iface.addDockWidget(
             Qt.RightDockWidgetArea, self.quickQueryDockWidget)


### PR DESCRIPTION
A description of the problem can be found here https://github.com/3liz/QuickOSM/issues/61

The following lines had been removed from quick_osm.py in a commit on Mar 16, 2015 "add icons to menu, add dock menu" 
self.iface.addPluginToWebMenu(u"&Quick OSM",self.osmFileAction)
self.iface.addPluginToWebMenu(u"&Quick OSM",self.myQueriesAction)
self.iface.addPluginToWebMenu(u"&Quick OSM",self.queryAction)
self.iface.addPluginToWebMenu(u"&Quick OSM",self.quickQueryAction)

When they are added back the Web menu stops disappearing after Qgis is restarted and so far I haven't seen it cause any other problems. However, I don't know why they were removed and it could have been for a good reason so keep that in mind when trying this patch.
